### PR TITLE
updated to net10 in csproj

### DIFF
--- a/IterationStatements/IterationStatements.csproj
+++ b/IterationStatements/IterationStatements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target framework for the `IterationStatements` project to use a newer version of .NET.

Project configuration update:

* Upgraded the `TargetFramework` in `IterationStatements.csproj` from `net9.0` to `net10.0`, ensuring the project builds against the latest .NET features and improvements.